### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Waffle.io - Columns and their card count](https://badge.waffle.io/UCSolarCarTeam/Epsilon-Dashboard.png?columns=all)](https://waffle.io/UCSolarCarTeam/Epsilon-Dashboard?utm_source=badge)
 # Epsilon-Dashboard
 
 The Epsilon Dashboard displays information on the screens.


### PR DESCRIPTION
Merge this to receive a badge indicating columns and number of cards in your columns on your waffle.io board at https://waffle.io/UCSolarCarTeam/Epsilon-Dashboard

This was requested by a real person (user bill-luu) on waffle.io, we're not trying to spam you.

Closes #81