### PR TITLE
Fix cell voltage not updating in race and display mode

### DIFF
--- a/src/ViewLayer/DisplayDashboard/DisplayDashboardView/DisplayDashboardView.cpp
+++ b/src/ViewLayer/DisplayDashboard/DisplayDashboardView/DisplayDashboardView.cpp
@@ -77,12 +77,12 @@ void DisplayDashboardView::connectBattery(BatteryPresenter& batteryPresenter)
             this, SLOT(packStateOfChargeReceived(double)));
     connect(&batteryPresenter, SIGNAL(highTemperatureReceived(int)),
             this, SLOT(highTemperatureReceived(int)));
-    connect(&batteryPresenter, SIGNAL(lowCellVoltageReceived(int)),
-            this, SLOT(lowCellVoltageReceived(int)));
+    connect(&batteryPresenter, SIGNAL(lowCellVoltageReceived(float)),
+            this, SLOT(lowCellVoltageReceived(float)));
     connect(&batteryPresenter, SIGNAL(averageTemperatureReceived(int)),
             this, SLOT(averageTemperatureReceived(int)));
-    connect(&batteryPresenter, SIGNAL(averageCellVoltageReceived(int)),
-            this, SLOT(averageCellVoltageReceived(int)));
+    connect(&batteryPresenter, SIGNAL(averageCellVoltageReceived(float)),
+            this, SLOT(averageCellVoltageReceived(float)));
 }
 
 void DisplayDashboardView::connectBatteryFaults(BatteryFaultsPresenter& batteryFaultsPresenter)
@@ -209,7 +209,7 @@ void DisplayDashboardView::highTemperatureReceived(int maxCellTemp)
 {
     ui_.maxCellTemperatureLabel().setNum(maxCellTemp);
 }
-void DisplayDashboardView::lowCellVoltageReceived(int lowestCellVoltage)
+void DisplayDashboardView::lowCellVoltageReceived(float lowestCellVoltage)
 {
     ui_.lowestCellVoltageLabel().setNum(lowestCellVoltage);
 }
@@ -217,7 +217,7 @@ void DisplayDashboardView::averageTemperatureReceived(int averageCellTemp)
 {
     ui_.avgCellTemperatureLabel().setNum(averageCellTemp);
 }
-void DisplayDashboardView::averageCellVoltageReceived(int averageVoltage)
+void DisplayDashboardView::averageCellVoltageReceived(float averageVoltage)
 {
     ui_.avgCellVoltageLabel().setNum(averageVoltage);
 }

--- a/src/ViewLayer/DisplayDashboard/DisplayDashboardView/DisplayDashboardView.h
+++ b/src/ViewLayer/DisplayDashboard/DisplayDashboardView/DisplayDashboardView.h
@@ -92,9 +92,9 @@ private slots:
     void packNetPowerReceived(double);
     void packStateOfChargeReceived(double);
     void highTemperatureReceived(int);
-    void lowCellVoltageReceived(int);
+    void lowCellVoltageReceived(float);
     void averageTemperatureReceived(int);
-    void averageCellVoltageReceived(int);
+    void averageCellVoltageReceived(float);
 
     // battery faults slots
     void errorFlagsReceived(BatteryErrorFlags);

--- a/src/ViewLayer/RaceModeDisplay/RaceModeDashboardView.cpp
+++ b/src/ViewLayer/RaceModeDisplay/RaceModeDashboardView.cpp
@@ -78,10 +78,10 @@ void RaceModeDashboardView::connectBattery(BatteryPresenter& batteryPresenter)
             this, SLOT(packNetPowerReceived(double)));
     connect(&batteryPresenter, SIGNAL(packStateOfChargeReceived(double)),
             this, SLOT(packStateOfChargeReceived(double)));
-    connect(&batteryPresenter, SIGNAL(lowCellVoltageReceived(int)),
-            this, SLOT(lowCellVoltageReceived(int)));
-    connect(&batteryPresenter, SIGNAL(averageCellVoltageReceived(int)),
-            this, SLOT(averageCellVoltageReceived(int)));
+    connect(&batteryPresenter, SIGNAL(lowCellVoltageReceived(float)),
+            this, SLOT(lowCellVoltageReceived(float)));
+    connect(&batteryPresenter, SIGNAL(averageCellVoltageReceived(float)),
+            this, SLOT(averageCellVoltageReceived(float)));
     connect(&batteryPresenter, SIGNAL(highTemperatureReceived(int)),
             this, SLOT(highTemperatureReceived(int)));
     connect(&batteryPresenter, SIGNAL(averageTemperatureReceived(int)),
@@ -198,12 +198,12 @@ void RaceModeDashboardView::packStateOfChargeReceived(double stateOfCharge)
     ui_.stateOfChargeCapacityWidget().setValue(stateOfCharge);
 }
 
-void RaceModeDashboardView::lowCellVoltageReceived(int lowVoltage)
+void RaceModeDashboardView::lowCellVoltageReceived(float lowVoltage)
 {
     ui_.lowestCellVoltageLabel().setNum(lowVoltage);
 }
 
-void RaceModeDashboardView::averageCellVoltageReceived(int averageVoltage)
+void RaceModeDashboardView::averageCellVoltageReceived(float averageVoltage)
 {
     ui_.avgCellVoltageLabel().setNum(averageVoltage);
 }

--- a/src/ViewLayer/RaceModeDisplay/RaceModeDashboardView.h
+++ b/src/ViewLayer/RaceModeDisplay/RaceModeDashboardView.h
@@ -82,8 +82,8 @@ private slots:
     void packNetPowerReceived(double);
     void auxVoltageReceived(int);
     void packStateOfChargeReceived(double);
-    void lowCellVoltageReceived(int);
-    void averageCellVoltageReceived(int);
+    void lowCellVoltageReceived(float);
+    void averageCellVoltageReceived(float);
     void highTemperatureReceived(int);
     void averageTemperatureReceived(int);
 


### PR DESCRIPTION
The signal was using int instead of float.

Fixes #154 