### PR TITLE
Fix bug with the battery state of charge circle on the race dashboard

### DIFF
--- a/src/ViewLayer/RaceModeDisplay/RaceModeDashboardUI.ui
+++ b/src/ViewLayer/RaceModeDisplay/RaceModeDashboardUI.ui
@@ -754,26 +754,6 @@ color: rgb(100,100,100);
               <property name="sizeConstraint">
                <enum>QLayout::SetMinimumSize</enum>
               </property>
-              <item row="1" column="0">
-               <widget class="QWidget" name="prechargeStateIconWidget" native="true">
-                <property name="minimumSize">
-                 <size>
-                  <width>45</width>
-                  <height>45</height>
-                 </size>
-                </property>
-                <property name="maximumSize">
-                 <size>
-                  <width>45</width>
-                  <height>45</height>
-                 </size>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">border-image: url(:/Resources/Alive Icon.png) 0 0 0 0 stretch stretch;
-</string>
-                </property>
-               </widget>
-              </item>
               <item row="2" column="0" colspan="2" alignment="Qt::AlignLeft">
                <widget class="QLabel" name="prechargeStateTitleLabel">
                 <property name="sizePolicy">
@@ -801,20 +781,8 @@ color: rgb(100,100,100);
                 <property name="text">
                  <string>    P R E C H A R G E</string>
                 </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QLabel" name="prechargeStateLabel">
-                <property name="font">
-                 <font>
-                  <pointsize>13</pointsize>
-                 </font>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">color: rgb(100,100,100);</string>
-                </property>
-                <property name="text">
-                 <string>RUN</string>
+                <property name="alignment">
+                 <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
                 </property>
                </widget>
               </item>
@@ -833,6 +801,24 @@ color: rgb(100,100,100);
                  </size>
                 </property>
                </spacer>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="prechargeStateLabel">
+                <property name="font">
+                 <font>
+                  <pointsize>13</pointsize>
+                 </font>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">color: rgb(100,100,100);</string>
+                </property>
+                <property name="text">
+                 <string>RUN</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
               </item>
              </layout>
             </item>
@@ -1128,7 +1114,7 @@ background: url(:/Resources/Thermometer.png);
         <rect>
          <x>-20</x>
          <y>0</y>
-         <width>369</width>
+         <width>372</width>
          <height>231</height>
         </rect>
        </property>

--- a/src/ViewLayer/RaceModeDisplay/RaceModeDisplayUI/I_RaceModeDashboardUI.h
+++ b/src/ViewLayer/RaceModeDisplay/RaceModeDisplayUI/I_RaceModeDashboardUI.h
@@ -26,8 +26,6 @@ public:
     virtual QWidget& motorResetButtonWidget() = 0;
 
     virtual QProgressBar& stateOfChargeCapacityWidget() = 0;
-
-    virtual QWidget& prechargeStateIconWidget() = 0;
     virtual QLabel& prechargeStateLabel() = 0;
 
     virtual QWidget& lowHeadlightIndicatorWidget() = 0;

--- a/src/ViewLayer/RaceModeDisplay/RaceModeDisplayUI/RaceModeDashboardUI.cpp
+++ b/src/ViewLayer/RaceModeDisplay/RaceModeDisplayUI/RaceModeDashboardUI.cpp
@@ -80,11 +80,6 @@ QProgressBar& RaceModeDashboardUI::stateOfChargeCapacityWidget()
     return *ui_->stateOfChargeCapacityWidget;
 }
 
-QWidget& RaceModeDashboardUI::prechargeStateIconWidget()
-{
-    return *ui_->prechargeStateIconWidget;
-}
-
 QLabel& RaceModeDashboardUI::prechargeStateLabel()
 {
     return *ui_->prechargeStateLabel;

--- a/src/ViewLayer/RaceModeDisplay/RaceModeDisplayUI/RaceModeDashboardUI.h
+++ b/src/ViewLayer/RaceModeDisplay/RaceModeDisplayUI/RaceModeDashboardUI.h
@@ -32,8 +32,6 @@ public:
     QWidget& motorResetButtonWidget();
 
     QProgressBar& stateOfChargeCapacityWidget();
-
-    QWidget& prechargeStateIconWidget();
     QLabel& prechargeStateLabel();
 
     QWidget& lowHeadlightIndicatorWidget();


### PR DESCRIPTION
Battery state of charge circle never changes

Fixed by deleting the widget, and its associated method, and aligning the state of charge with the label
Fixes #156 