### PR TITLE
Fix bug with Battery Precharge State label

### DIFF
--- a/src/ViewLayer/DisplayDashboard/DisplayDashboardUI.ui
+++ b/src/ViewLayer/DisplayDashboard/DisplayDashboardUI.ui
@@ -1234,7 +1234,7 @@ qproperty-alignment: 'AlignHCenter';
            <property name="spacing">
             <number>0</number>
            </property>
-           <item row="1" column="1">
+           <item row="1" column="1" alignment="Qt::AlignHCenter">
             <widget class="QLabel" name="prechargeStateTitleLabel">
              <property name="styleSheet">
               <string notr="true">color: rgb(100,100,100);</string>
@@ -1244,7 +1244,7 @@ qproperty-alignment: 'AlignHCenter';
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
+           <item row="0" column="1" alignment="Qt::AlignHCenter">
             <widget class="QLabel" name="prechargeStateLabel">
              <property name="styleSheet">
               <string notr="true">color: rgb(100,100,100);</string>

--- a/src/ViewLayer/DisplayDashboard/DisplayDashboardUI.ui
+++ b/src/ViewLayer/DisplayDashboard/DisplayDashboardUI.ui
@@ -1250,7 +1250,7 @@ qproperty-alignment: 'AlignHCenter';
               <string notr="true">color: rgb(100,100,100);</string>
              </property>
              <property name="text">
-              <string>RUN</string>
+              <string>Off</string>
              </property>
             </widget>
            </item>

--- a/src/ViewLayer/DisplayDashboard/DisplayDashboardUI.ui
+++ b/src/ViewLayer/DisplayDashboard/DisplayDashboardUI.ui
@@ -1234,8 +1234,15 @@ qproperty-alignment: 'AlignHCenter';
            <property name="spacing">
             <number>0</number>
            </property>
-           <item row="0" column="0">
-            <widget class="QWidget" name="prechargeStateIconWidget" native="true"/>
+           <item row="1" column="1">
+            <widget class="QLabel" name="prechargeStateTitleLabel">
+             <property name="styleSheet">
+              <string notr="true">color: rgb(100,100,100);</string>
+             </property>
+             <property name="text">
+              <string>P R E C H A R G E</string>
+             </property>
+            </widget>
            </item>
            <item row="0" column="1">
             <widget class="QLabel" name="prechargeStateLabel">
@@ -1247,15 +1254,11 @@ qproperty-alignment: 'AlignHCenter';
              </property>
             </widget>
            </item>
-           <item row="1" column="0" colspan="2">
-            <widget class="QLabel" name="prechargeStateTitleLabel">
-             <property name="styleSheet">
-              <string notr="true">color: rgb(100,100,100);</string>
-             </property>
-             <property name="text">
-              <string>P R E C H A R G E</string>
-             </property>
-            </widget>
+           <item row="0" column="0">
+            <widget class="QWidget" name="prechargeStateIconWidget" native="true"/>
+           </item>
+           <item row="1" column="0">
+            <widget class="QWidget" name="prechargeStateIconWidget_2" native="true"/>
            </item>
           </layout>
          </widget>


### PR DESCRIPTION
Battery Precharge label  is no longer misaligned with the Battery Precharge State.

fixes #153 