### PR TITLE
Removes Tool Tip from Hovering Over the mppt Tab in the Debug Display

### DIFF
--- a/src/ViewLayer/DebugDisplay/Tab/TabUi/TabUi.ui
+++ b/src/ViewLayer/DebugDisplay/Tab/TabUi/TabUi.ui
@@ -633,7 +633,7 @@ border-bottom: 1px solid white;
          </size>
         </property>
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string/>
         </property>
         <property name="styleSheet">
          <string notr="true">QPushButton{


### PR DESCRIPTION
fixes #179 