### PR TITLE
fix the "No such slot" error that occurs when the display dashboard is run

### DIFF
--- a/src/ViewLayer/DisplayDashboard/DisplayDashboardView/DisplayDashboardView.cpp
+++ b/src/ViewLayer/DisplayDashboard/DisplayDashboardView/DisplayDashboardView.cpp
@@ -105,8 +105,6 @@ void DisplayDashboardView::connectDriverControls(DriverControlsPresenter& driver
 {
     connect(&driverControlsPresenter, SIGNAL(resetReceived(bool)),
             this, SLOT(resetReceived(bool)));
-    connect(&driverControlsPresenter, SIGNAL(brakesReceived(bool)),
-            this, SLOT(brakesReceived(bool)));
     connect(&driverControlsPresenter, SIGNAL(forwardReceived(bool)),
             this, SLOT(forwardReceived(bool)));
     connect(&driverControlsPresenter, SIGNAL(reverseReceived(bool)),


### PR DESCRIPTION
fixes #212 