### PR TITLE
Update Script to Re-use Development Resources scripts

### DIFF
--- a/EpsilonDashboardSetup.sh
+++ b/EpsilonDashboardSetup.sh
@@ -1,31 +1,18 @@
 #!/usr/bin/env bash
+if [ "$(id -u)" != "0" ]; then
+    echo "Permission Denied. Please run as root"
+    exit 1
+fi
 
 echo 'deb http://www.rabbitmq.com/debian/ testing main' | sudo tee /etc/apt/sources.list.d/rabbitmq.list && sudo apt-get update && sudo apt-get install rabbitmq-server
 sudo apt-get install cmake libboost-dev openssl libssl-dev libblkid-dev e2fslibs-dev libboost-all-dev libaudit-dev software-properties-common build-essential mesa-common-dev libgl1-mesa-dev
+(
+	cd /tmp/
+	git clone https://github.com/UCSolarCarTeam/Development-Resources.git
+	sudo ./Development-Resources/InstallScripts/googletest-setup.sh
+	sudo ./Development-Resources/InstallScripts/rabbitmq-setup.sh
+)
 
-cd /tmp/
-if ls /usr/local/lib/librabbitmq.* 1> /dev/null 2>&1 ;
-then
-echo "Rabbitmq already setup"
-else
-git clone https://github.com/alanxz/rabbitmq-c
-mkdir rabbitmq-c/build && cd rabbitmq-c/build
-cmake ..
-cmake --build .
-sudo cp librabbitmq/*.a /usr/local/lib/
-sudo cp librabbitmq/*.so* /usr/local/lib/
-fi
-
-cd /tmp/
-if ls /usr/local/libSimpleAmqpClient.* 1> /dev/null 2>&1 || [ -d /usr/local/include/SimpleAmqpClient ];
-then
-echo "SimpleAmqpClient already setup"
-else
-git clone https://github.com/alanxz/SimpleAmqpClient
-mkdir SimpleAmqpClient/build && cd SimpleAmqpClient/build
-cmake -DRabbitmqc_INCLUDE_DIR=../../rabbitmq-c/librabbitmq -DRabbitmqc_LIBRARY=../../rabbitmq-c/build/librabbitmq ..
-make
-sudo mkdir /usr/local/include/SimpleAmqpClient
-sudo cp *.so* /usr/local/lib/
-sudo cp ../src/SimpleAmqpClient/*.h /usr/local/include/SimpleAmqpClient
+if [ ! -f build/config.ini ]; then
+    cp src/config.ini.example build/config.ini
 fi


### PR DESCRIPTION
Now uses rabbitmq and googletest/googlemock scripts from development resources
Moves Config.ini.example to build folder and renames it to Config.ini