### PR TITLE
SFT-88 Modified build output structure to allow shadow builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
     - PATH="/opt/qt512/bin:$PATH"
     - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
     - qt512-env.sh
-    - mkdir -p build/.lib/
+    - mkdir -p build/thirdparty/googletest/.lib/
 
 install:
      # install googletest and googlemock
@@ -43,7 +43,7 @@ install:
            -c
            googletest/src/gtest-all.cc &&
        ar -rv libgmock.a gtest-all.o gmock-all.o)
-    - cp googletest/libgmock.a build/.lib/
+    - cp googletest/libgmock.a build/thirdparty/googletest/.lib/
     - cd /tmp/
     # install astyle
     - (wget 'https://s3-us-west-2.amazonaws.com/ucsolarteam.hostedfiles/astyle' && tar -zxvf astyle)
@@ -58,8 +58,8 @@ install:
 
 script: 
     - "! (astyle *.h *.cpp -r --dry-run --options=astylerc --exclude=googletest | grep Formatted)"
-    - cd src
-    - qmake
+    - cd build
+    - qmake ../src/
     - make
     - make check
 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,21 @@ To install these dependencies, run the command:
 ## Config file
 
 Create a copy of the `config.ini.example` file in the `build` directory called `config.ini` and update any necessary settings.
+
+## Building via Command Line
+
+Create a new directory for your build & navigate into it:
+
+`mkdir build && cd build`
+
+Call qmake, passing in the directory with the root `EpsilonDashboard.pro` to generate the makefile:
+
+`qmake <path-to-source-pro>`
+
+Later you need to re-run qmake on the project due to a new UI file or a change to a .pro, call:
+
+`make qmake_all`
+
+Build with:
+
+`make -j4`

--- a/src/BusinessLayer/BusinessLayer.pro
+++ b/src/BusinessLayer/BusinessLayer.pro
@@ -5,7 +5,7 @@ CONFIG += staticlib
     error("Could not find common.pri file!")
 }
 
-DESTDIR = ../../build/.lib
+DESTDIR = .lib
 
 HEADERS += \
     BusinessContainer.h \

--- a/src/CommunicationLayer/CommunicationLayer.pro
+++ b/src/CommunicationLayer/CommunicationLayer.pro
@@ -5,7 +5,7 @@ CONFIG += staticlib
     error("Could not find common.pri file!")
 }
 
-DESTDIR = ../../build/.lib
+DESTDIR = .lib
 
 HEADERS += \
     CommDeviceControl/CommDefines.h \

--- a/src/DataLayer/DataLayer.pro
+++ b/src/DataLayer/DataLayer.pro
@@ -5,7 +5,7 @@ CONFIG += staticlib
     error("Could not find common.pri file!")
 }
 
-DESTDIR = ../../build/.lib
+DESTDIR = .lib
 
 HEADERS += \
     DataContainer.h \

--- a/src/EpsilonDashboard/EpsilonDashboard.pro
+++ b/src/EpsilonDashboard/EpsilonDashboard.pro
@@ -1,15 +1,26 @@
 TEMPLATE = app
-LIBS += -L../../build/.lib -lViewLayer -lCommunicationLayer -lBusinessLayer -lDataLayer -lPresenterLayer -lInfrastructureLayer
+LIBS += \
+    -L../ViewLayer/.lib -lViewLayer \
+    -L../CommunicationLayer/.lib -lCommunicationLayer \
+    -L../BusinessLayer/.lib -lBusinessLayer \
+    -L../DataLayer/.lib -lDataLayer \
+    -L../PresenterLayer/.lib -lPresenterLayer \
+    -L../InfrastructureLayer/.lib -lInfrastructureLayer
 
 ! include(../common.pri){
     error("Could not find common.pri file!")
 }
 PRE_TARGETDEPS += \
- ../../build/.lib/*
+    ../ViewLayer/.lib/* \
+    ../CommunicationLayer/.lib/* \
+    ../BusinessLayer/.lib/* \
+    ../DataLayer/.lib/* \
+    ../PresenterLayer/.lib/* \
+    ../InfrastructureLayer/.lib/*
 
 TARGET = EpsilonDashboard
 
-DESTDIR = ../../build
+DESTDIR = ../bin
 
 SOURCES += \
     main.cpp \
@@ -36,3 +47,7 @@ DISTFILES += \
     ../Resources/HighHeadlightIndicator.png \
     ../Resources/LowHeadlightIndicator.png \
     ../Resources/SolarCarTeam.png
+
+copyconfigfile.commands = cp $$PWD/../config.ini.example ../bin/config.ini
+QMAKE_EXTRA_TARGETS += copyconfigfile
+POST_TARGETDEPS += copyconfigfile

--- a/src/InfrastructureLayer/InfrastructureLayer.pro
+++ b/src/InfrastructureLayer/InfrastructureLayer.pro
@@ -5,7 +5,7 @@ CONFIG += staticlib
     error( "Couldn't find the common.pri file!" )
 }
 
-DESTDIR = ../../build/.lib
+DESTDIR = .lib
 
 HEADERS += \
     InfrastructureContainer.h \

--- a/src/PresenterLayer/PresenterLayer.pro
+++ b/src/PresenterLayer/PresenterLayer.pro
@@ -5,7 +5,7 @@ CONFIG += staticlib
     error("Could not find common.pri file!")
 }
 
-DESTDIR = ../../build/.lib
+DESTDIR = .lib
 
 HEADERS += \
     BatteryPresenter/BatteryPresenter.h \ 

--- a/src/Tests/Tests.pro
+++ b/src/Tests/Tests.pro
@@ -2,7 +2,14 @@ TEMPLATE = app
 QT += testlib
 CONFIG += testcase c++11
 
-LIBS += -L../../build/.lib -lBusinessLayer -lgmock -lViewLayer -lCommunicationLayer -lInfrastructureLayer -lDataLayer -lPresenterLayer
+LIBS += \
+    -L../ViewLayer/.lib -lViewLayer \
+    -L../CommunicationLayer/.lib -lCommunicationLayer \
+    -L../BusinessLayer/.lib -lBusinessLayer \
+    -L../DataLayer/.lib -lDataLayer \
+    -L../PresenterLayer/.lib -lPresenterLayer \
+    -L../InfrastructureLayer/.lib -lInfrastructureLayer \
+    -L../thirdparty/googletest/.lib -lgmock
 
 SOURCES += \
     CommunicationLayer/JsonReceiver/JsonReceiverTest.cpp \
@@ -13,12 +20,12 @@ SOURCES += \
     QMAKE_CXXFLAGS +=
 }
 
-DESTDIR = ../../build/tests/
+DESTDIR = ../bin/tests/
 
-copyfiles.commands = cp testconfig.ini $${DESTDIR}
+copytestconfig.commands = cp $$PWD/testconfig.ini $${DESTDIR}
 
-QMAKE_EXTRA_TARGETS += copyfiles
-POST_TARGETDEPS += copyfiles
+QMAKE_EXTRA_TARGETS += copytestconfig
+POST_TARGETDEPS += copytestconfig
 
 HEADERS += \
     CommunicationLayer/mockcommdevicemanager.h \

--- a/src/ViewLayer/ViewLayer.pro
+++ b/src/ViewLayer/ViewLayer.pro
@@ -5,7 +5,7 @@ CONFIG += staticlib
     error("Could not find common.pri file!")
 }
 
-DESTDIR = ../../build/.lib
+DESTDIR = .lib
 
 HEADERS += \
     DebugDisplay/BatteryPage/BatteryUi/BatteryUi.h \

--- a/src/common.pri
+++ b/src/common.pri
@@ -5,11 +5,9 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets network
 CONFIG += static c++11
 
 QMAKE_CXXFLAGS += -Wno-expansion-to-defined
-RCC_DIR= ../release
-DESTDIR = ../release
-OBJECTS_DIR = ../release/.obj
-MOC_DIR = ../release/.moc
-RCC_DIR = ../release/.rcc
-UI_DIR = ../release/.ui
+OBJECTS_DIR = .obj
+MOC_DIR = .moc
+RCC_DIR = .rcc
+UI_DIR = .ui
 
 LIBS += -lSimpleAmqpClient -lrabbitmq


### PR DESCRIPTION
Remove explicit references to a `build` folder, so the outputs can be placed anywhere the developer wants. The proper way of using qmake is to create the build directory, and calling qmake from that build directory to generate the makefile.

The executable will now be located in `<build-folder>/bin`. Other libraries will have a folder containing `.lib`,`.moc`, `.obj` folders for those artifacts.

In addition, a new copyconfigfile command was added, that will copy the config.ini next to the executable post-build.

The main fix that will be noticed is that the project can now be built using the shadow build option in QT Creator (basically, instead of needing the outputs in the build folder, it can be done anywhere).
![image](https://user-images.githubusercontent.com/15304203/71432509-74d11c80-2697-11ea-8a7a-4ff0e20ff860.png)

Merry Christmas!
![image](https://user-images.githubusercontent.com/15304203/71432525-8b777380-2697-11ea-86de-a5bd76c6036f.png)
 