### PR TITLE
SFT-93 Add Conan as a dependency manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 Makefile
 release
 .DS_Store
-build*
+/build*/
 *.TIPBGT
 *.o
 *.stash

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,50 +15,24 @@ before_install:
         libboost-chrono-dev
         libboost-system-dev
         libgl1-mesa-dev
+        python3-pip
     - PATH="/opt/qt512/bin:$PATH"
     - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
     - qt512-env.sh
-    - mkdir -p build/thirdparty/googletest/.lib/
 
 install:
-     # install googletest and googlemock
-    - git clone https://github.com/google/googletest.git
-    - sudo cp -r googletest/googletest/include/gtest /usr/local/include
-    - sudo cp -r googletest/googlemock/include/gmock /usr/local/include
-    - (cd googletest &&
-       g++ -std=c++11
-           -isystem googletest/include/
-           -Igoogletest
-           -isystem googlemock/include/
-           -Igooglemock
-           -pthread
-           -c
-           googlemock/src/gmock-all.cc &&
-       g++ -std=c++11
-           -isystem googletest/include/
-           -Igoogletest
-           -isystem googlemock/include/
-           -Igooglemock
-           -pthread
-           -c
-           googletest/src/gtest-all.cc &&
-       ar -rv libgmock.a gtest-all.o gmock-all.o)
-    - cp googletest/libgmock.a build/thirdparty/googletest/.lib/
-    - cd /tmp/
+    # install conan
+    - sudo pip install conan
+    - conan remote add conan-dbely https://api.bintray.com/conan/dbely/conan
     # install astyle
+    - cd /tmp
     - (wget 'https://s3-us-west-2.amazonaws.com/ucsolarteam.hostedfiles/astyle' && tar -zxvf astyle)
-    - (cd ./astyle/build/gcc && make release && sudo make install && rm astyle -rf)
-    #install rabbitmq-c
-    - git clone https://github.com/alanxz/rabbitmq-c
-    - (cd rabbitmq-c && sudo cp librabbitmq/*.h /usr/local/include/ && mkdir build && cd build && cmake .. && cmake --build . && sudo cp librabbitmq/librabbitmq.a /usr/local/lib/ && sudo cp librabbitmq/*.so* /usr/local/lib/)
-    #install SimpleAmqpClient
-    - git clone https://github.com/alanxz/SimpleAmqpClient
-    - (cd SimpleAmqpClient && mkdir build && cd build && cmake -DRabbitmqc_INCLUDE_DIR=../../rabbitmq-c/librabbitmq -DRabbitmqc_LIBRARY=../../rabbitmq-c/build/librabbitmq .. && make && sudo mkdir /usr/local/include/SimpleAmqpClient && sudo cp *.so* /usr/local/lib/ && sudo cp ../src/SimpleAmqpClient/*.h /usr/local/include/SimpleAmqpClient/)
-    - cd $TRAVIS_BUILD_DIR
+    - (cd ./astyle/build/gcc && make release && sudo make install)
 
 script: 
-    - "! (astyle *.h *.cpp -r --dry-run --options=astylerc --exclude=googletest | grep Formatted)"
-    - cd build
+    - cd $TRAVIS_BUILD_DIR
+    - "! (astyle *.h *.cpp -r --dry-run --options=astylerc | grep Formatted)"
+    - mkdir build && cd build
     - qmake ../src/
     - make
     - make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,16 @@ before_install:
         libboost-system-dev
         libgl1-mesa-dev
         python3-pip
+        python3-setuptools
     - PATH="/opt/qt512/bin:$PATH"
     - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
     - qt512-env.sh
 
 install:
     # install conan
-    - sudo pip install conan
+    - pip3 install conan
     - conan remote add conan-dbely https://api.bintray.com/conan/dbely/conan
+
     # install astyle
     - cd /tmp
     - (wget 'https://s3-us-west-2.amazonaws.com/ucsolarteam.hostedfiles/astyle' && tar -zxvf astyle)
@@ -33,6 +35,7 @@ script:
     - cd $TRAVIS_BUILD_DIR
     - "! (astyle *.h *.cpp -r --dry-run --options=astylerc | grep Formatted)"
     - mkdir build && cd build
+    - conan install .. --build=missing
     - qmake ../src/
     - make
     - make check

--- a/EpsilonDashboardSetup.sh
+++ b/EpsilonDashboardSetup.sh
@@ -5,14 +5,6 @@ if [ "$(id -u)" != "0" ]; then
 fi
 
 echo 'deb http://www.rabbitmq.com/debian/ testing main' | sudo tee /etc/apt/sources.list.d/rabbitmq.list && sudo apt-get update && sudo apt-get install rabbitmq-server
-sudo apt-get install cmake libboost-dev openssl libssl-dev libblkid-dev e2fslibs-dev libboost-all-dev libaudit-dev software-properties-common build-essential mesa-common-dev libgl1-mesa-dev
-(
-	cd /tmp/
-	git clone https://github.com/UCSolarCarTeam/Development-Resources.git
-	sudo ./Development-Resources/InstallScripts/googletest-setup.sh
-	sudo ./Development-Resources/InstallScripts/rabbitmq-setup.sh
-)
-
-if [ ! -f build/config.ini ]; then
-    cp src/config.ini.example build/config.ini
-fi
+apt-get install cmake openssl libssl-dev libblkid-dev e2fslibs-dev libaudit-dev software-properties-common build-essential mesa-common-dev libgl1-mesa-dev python3-pip
+pip install conan
+conan remote add conan-dbely https://api.bintray.com/conan/dbely/conan

--- a/EpsilonDashboardSetup.sh
+++ b/EpsilonDashboardSetup.sh
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
-if [ "$(id -u)" != "0" ]; then
-    echo "Permission Denied. Please run as root"
-    exit 1
-fi
+echo 'deb http://www.rabbitmq.com/debian/ testing main' | sudo tee /etc/apt/sources.list.d/rabbitmq.list
+sudo apt-get install -y cmake \
+        openssl \
+        libssl-dev \
+        libblkid-dev \
+        e2fslibs-dev \
+        libaudit-dev \
+        software-properties-common \
+        build-essential \
+        mesa-common-dev \
+        libgl1-mesa-dev \
+        python3-pip \
+        rabbitmq-server \
+        python3-setuptools
 
-echo 'deb http://www.rabbitmq.com/debian/ testing main' | sudo tee /etc/apt/sources.list.d/rabbitmq.list && sudo apt-get update && sudo apt-get install rabbitmq-server
-apt-get install cmake openssl libssl-dev libblkid-dev e2fslibs-dev libaudit-dev software-properties-common build-essential mesa-common-dev libgl1-mesa-dev python3-pip
-pip install conan
+pip3 install --user conan
+echo 'export PATH=$PATH:~/.local/bin/' >> ~/.profile
+source ~/.profile
 conan remote add conan-dbely https://api.bintray.com/conan/dbely/conan

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In this repo, there are dependencies needed for before you will be able to build
 
 To install these dependencies, run the setup script:
 
-`sudo ./EpsilonDashboardSetup.sh`
+`./EpsilonDashboardSetup.sh`
 
 This will install the [RabbitMQ](https://www.rabbitmq.com/) server and the [Conan](https://conan.io/) package manager. See the links for more information.
 
@@ -22,8 +22,8 @@ When first setting up your project with QT creator, you must first add a custom 
 1. Navigate to `Projects -> Build`
 2. In `Build Steps`, select `Add Build Step -> Custom Process Step`
 3. Add the conan command to the step
-   - Command: `conan`
-   - Arguments: `install --build=missing -s compiler.libcxx="libstdc++11"`
+   - Command: `$HOME/.local/bin/conan`
+   - Arguments: `install /path/to/conanfile.txt --build=missing -s compiler.libcxx="libstdc++11"`
    - Working Directory: `%{buildDir}`
 4. Move the step to occur as the first step in the process
 
@@ -31,32 +31,35 @@ When first setting up your project with QT creator, you must first add a custom 
 
 1. Create a new directory for your build & navigate into it:
 
-	`mkdir build && cd build`
+    `mkdir build && cd build`
 
-2. Install conan dependencies:
+2. If you were running this on the same terminal you ran the setup script on, reload your environment:
+   `source ~/.profile`
 
-	`conan install <path/to/conanfile.txt> --build=missing -s compiler.libcxx="libstdc++11"`
-	
+3. Install conan dependencies:
+
+    `conan install /path/to/conanfile.txt --build=missing -s compiler.libcxx="libstdc++11"`
+
 3. Call qmake, passing in the directory with the root `EpsilonDashboard.pro` to generate the makefile:
 
-	`qmake <path-to-source-pro>`
+    `qmake /path/to/EpsilonDashboard.pro`
 
 - Later, if you need to re-run qmake on the project due to a new UI file or a change to a .pro, call:
 
-	`make qmake_all`
+    `make qmake_all`
 
-4. Build:
+1. Build:
 
-	`make -j4`
+    `make -j4`
 
-### Cross Compilation
+## Cross Compilation
 
 First, make sure you have followed the [steps](https://github.com/UCSolarCarTeam/Epsilon-Raspberry/tree/master/cross-compile/README.adoc) to set up a cross compilation environment on your computer.
 
 Cross compiling is the same as the above steps, with a few modifications:
 
 1. You must add an additional `-pr=<path/to/rpi_build>` to the `conan install` command.
-   - `conan install <path/to/conanfile.txt> --build=missing -pr=<path/tp/rpi_build>`
+   - `conan install /path/to/conanfile.txt --build=missing -pr=/path/tp/rpi_build`
 2. When calling qmake, it must be the qmake executed that you compiled for cross-compilation (e.g. `~/raspi/qt5/bin/qmake`).
 
 ## Running the Dashboard
@@ -69,13 +72,13 @@ An example can be found in `config.ini.example`, and any necessary settings can 
 ### Switching Modes
 
 There are three different modes for the dashboard: Display mode, Debug Display mode and race mode. The default mode is display mode.
-To run the application in different modes, navigate to the directory where you made the executable file for the dashboard. 
+To run the application in different modes, navigate to the directory where you made the executable file for the dashboard.
 
 To run the application in display mode, run the command:
-	`./EpsilonDashboard`
+    `./EpsilonDashboard`
 
 To run the application in debug display mode, run the command:
-	`./EpsilonDashboard -d`
-  
+    `./EpsilonDashboard -d`
+
 To run the application in race mode, add the -r flag at the end:
   `./EpsilonDashboard -r`

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ When first setting up your project with QT creator, you must first add a custom 
 2. In `Build Steps`, select `Add Build Step -> Custom Process Step`
 3. Add the conan command to the step
    - Command: `conan`
-   - Arguments: `install --build=missing compiler.libcxx="libstdc++11"`
+   - Arguments: `install --build=missing -s compiler.libcxx="libstdc++11"`
    - Working Directory: `%{buildDir}`
 4. Move the step to occur as the first step in the process
 
@@ -35,7 +35,7 @@ When first setting up your project with QT creator, you must first add a custom 
 
 2. Install conan dependencies:
 
-	`conan install <path/to/conanfile.txt> --build=missing compiler.libcxx="libstdc++11"`
+	`conan install <path/to/conanfile.txt> --build=missing -s compiler.libcxx="libstdc++11"`
 	
 3. Call qmake, passing in the directory with the root `EpsilonDashboard.pro` to generate the makefile:
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ To run the application in race mode, add the -r flag at the end:
 
 ## Setting up Rabbitmq
 
-In this repo, there are dependencies needed for Rabbitmq before you will be able to build or run anything.
+In this repo, there are dependencies needed for before you will be able to build or run anything.
 
 To install these dependencies, run the command:
 	`./EpsilonDashboardSetup.sh`
+
+This will install the [RabbitMQ](https://www.rabbitmq.com/) server and the [Conan](https://conan.io/) package manager. See the links for more information.
 
 ## Config file
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,70 @@
 
 The Epsilon Dashboard displays information on the screens.
 
-## Switching Modes
+## Project Setup
+
+In this repo, there are dependencies needed for before you will be able to build or run anything.
+
+To install these dependencies, run the setup script:
+
+`sudo ./EpsilonDashboardSetup.sh`
+
+This will install the [RabbitMQ](https://www.rabbitmq.com/) server and the [Conan](https://conan.io/) package manager. See the links for more information.
+
+## Building
+
+### QT Creator
+
+When first setting up your project with QT creator, you must first add a custom step to allow Conan to install dependencies.
+
+1. Navigate to `Projects -> Build`
+2. In `Build Steps`, select `Add Build Step -> Custom Process Step`
+3. Add the conan command to the step
+   - Command: `conan`
+   - Arguments: `install --build=missing compiler.libcxx="libstdc++11"`
+   - Working Directory: `%{buildDir}`
+4. Move the step to occur as the first step in the process
+
+### Command Line
+
+1. Create a new directory for your build & navigate into it:
+
+	`mkdir build && cd build`
+
+2. Install conan dependencies:
+
+	`conan install <path/to/conanfile.txt> --build=missing compiler.libcxx="libstdc++11"`
+	
+3. Call qmake, passing in the directory with the root `EpsilonDashboard.pro` to generate the makefile:
+
+	`qmake <path-to-source-pro>`
+
+- Later, if you need to re-run qmake on the project due to a new UI file or a change to a .pro, call:
+
+	`make qmake_all`
+
+4. Build:
+
+	`make -j4`
+
+### Cross Compilation
+
+First, make sure you have followed the [steps](https://github.com/UCSolarCarTeam/Epsilon-Raspberry/tree/master/cross-compile/README.adoc) to set up a cross compilation environment on your computer.
+
+Cross compiling is the same as the above steps, with a few modifications:
+
+1. You must add an additional `-pr=<path/to/rpi_build>` to the `conan install` command.
+   - `conan install <path/to/conanfile.txt> --build=missing -pr=<path/tp/rpi_build>`
+2. When calling qmake, it must be the qmake executed that you compiled for cross-compilation (e.g. `~/raspi/qt5/bin/qmake`).
+
+## Running the Dashboard
+
+### Config file
+
+There must be a `config.ini` beside the execuable to run properly.
+An example can be found in `config.ini.example`, and any necessary settings can be updated.
+
+### Switching Modes
 
 There are three different modes for the dashboard: Display mode, Debug Display mode and race mode. The default mode is display mode.
 To run the application in different modes, navigate to the directory where you made the executable file for the dashboard. 
@@ -16,34 +79,3 @@ To run the application in debug display mode, run the command:
   
 To run the application in race mode, add the -r flag at the end:
   `./EpsilonDashboard -r`
-
-## Setting up Rabbitmq
-
-In this repo, there are dependencies needed for before you will be able to build or run anything.
-
-To install these dependencies, run the command:
-	`./EpsilonDashboardSetup.sh`
-
-This will install the [RabbitMQ](https://www.rabbitmq.com/) server and the [Conan](https://conan.io/) package manager. See the links for more information.
-
-## Config file
-
-Create a copy of the `config.ini.example` file in the `build` directory called `config.ini` and update any necessary settings.
-
-## Building via Command Line
-
-Create a new directory for your build & navigate into it:
-
-`mkdir build && cd build`
-
-Call qmake, passing in the directory with the root `EpsilonDashboard.pro` to generate the makefile:
-
-`qmake <path-to-source-pro>`
-
-Later you need to re-run qmake on the project due to a new UI file or a change to a .pro, call:
-
-`make qmake_all`
-
-Build with:
-
-`make -j4`

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,9 +1,40 @@
 [requires]
 gtest/1.10.0
 SimpleAmqpClient/2.5.0-pre2@dbely/testing
+boost/[>1.69.0]@conan/stable
+openssl/1.1.1d
 
 [generators]
 qmake
 
 [options]
 *:shared=False
+
+# SimpleAmqpClient only requires atomic and chrono from boost
+boost:without_container=True
+boost:without_context=True
+boost:without_contract=True
+boost:without_coroutine=True
+boost:without_date_time=True
+boost:without_exception=True
+boost:without_fiber=True
+boost:without_filesystem=True
+boost:without_graph=True
+boost:without_graph_parallel=True
+boost:without_iostreams=True
+boost:without_locale=True
+boost:without_log=True
+boost:without_math=True
+boost:without_mpi=True
+boost:without_program_options=True
+boost:without_python=True
+boost:without_random=True
+boost:without_regex=True
+boost:without_serialization=True
+boost:without_stacktrace=True
+boost:without_system=True
+boost:without_test=True
+boost:without_thread=True
+boost:without_timer=True
+boost:without_type_erasure=True
+boost:without_wave=True

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,9 @@
+[requires]
+gtest/1.10.0
+SimpleAmqpClient/2.5.0-pre2@dbely/testing
+
+[generators]
+qmake
+
+[options]
+*:shared=False

--- a/rpi_build
+++ b/rpi_build
@@ -1,0 +1,32 @@
+target_host=arm-linux-gnueabihf
+# Set to path of gcc-linaro-arm-linux-gnueabihf-raspbian-x64 folder
+standalone_toolchain=~/raspi/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/
+sysroot_path=~/raspi/sysroot/
+cc_compiler=gcc
+cxx_compiler=g++
+
+[settings]
+os=Linux
+arch=armv8
+compiler=gcc
+compiler.version=4.8
+compiler.libcxx=libstdc++11
+build_type=Release
+
+[env]
+CONAN_CMAKE_FIND_ROOT_PATH=$sysroot_path
+PATH=[$standalone_toolchain/bin]
+CHOST=$target_host
+AR=$target_host-ar
+AS=$target_host-as
+ASFLAGS=-mfpu=neon-vfpv4
+RANLIB=$target_host-ranlib
+LD=$target_host-ld
+STRIP=$target_host-strip
+CC=$target_host-$cc_compiler
+CXX=$target_host-$cxx_compiler
+CXXFLAGS=-I"$standalone_toolchain/$target_host/lib/include"
+
+# OpenSSL builds under the wrong configuration under armv8
+# Forces OpenSSL to build as a generic linux device for Pi
+CONAN_OPENSSL_CONFIGURATION=linux-generic64

--- a/src/CommunicationLayer/CommunicationLayer.pro
+++ b/src/CommunicationLayer/CommunicationLayer.pro
@@ -1,8 +1,12 @@
 TEMPLATE = lib
-CONFIG += staticlib
+CONFIG += staticlib conan_basic_setup
 
 ! include(../common.pri){
     error("Could not find common.pri file!")
+}
+
+! include($$OUT_PWD/../conanbuildinfo.pri) {
+    error("Could not find conanbuildinfo.pri file!")
 }
 
 DESTDIR = .lib

--- a/src/EpsilonDashboard.pro
+++ b/src/EpsilonDashboard.pro
@@ -17,5 +17,3 @@ SUBDIRS = \
 DISTFILES += \
     .travis.yml \
     config.ini
-
-system(cd $$OUT_PWD; conan install .. --build=outdated -s compiler.libcxx="libstdc++11")

--- a/src/EpsilonDashboard.pro
+++ b/src/EpsilonDashboard.pro
@@ -17,3 +17,5 @@ SUBDIRS = \
 DISTFILES += \
     .travis.yml \
     config.ini
+
+system(cd $$OUT_PWD; conan install .. --build=outdated -s compiler.libcxx="libstdc++11")

--- a/src/EpsilonDashboard/EpsilonDashboard.pro
+++ b/src/EpsilonDashboard/EpsilonDashboard.pro
@@ -10,6 +10,14 @@ LIBS += \
 ! include(../common.pri){
     error("Could not find common.pri file!")
 }
+
+CONFIG += conan_basic_setup
+! include($$OUT_PWD/../conanbuildinfo.pri) {
+    error("Could not find conanbuildinfo.pri file!")
+}
+
+LIBS += -ldl
+
 PRE_TARGETDEPS += \
     ../ViewLayer/.lib/* \
     ../CommunicationLayer/.lib/* \

--- a/src/Tests/Tests.pro
+++ b/src/Tests/Tests.pro
@@ -1,6 +1,9 @@
 TEMPLATE = app
 QT += testlib
-CONFIG += testcase c++11
+CONFIG += testcase c++11 conan_basic_setup
+! include($$OUT_PWD/../conanbuildinfo.pri) {
+    error("Could not find conanbuildinfo.pri file!")
+}
 
 LIBS += \
     -L../ViewLayer/.lib -lViewLayer \
@@ -8,8 +11,7 @@ LIBS += \
     -L../BusinessLayer/.lib -lBusinessLayer \
     -L../DataLayer/.lib -lDataLayer \
     -L../PresenterLayer/.lib -lPresenterLayer \
-    -L../InfrastructureLayer/.lib -lInfrastructureLayer \
-    -L../thirdparty/googletest/.lib -lgmock
+    -L../InfrastructureLayer/.lib -lInfrastructureLayer
 
 SOURCES += \
     CommunicationLayer/JsonReceiver/JsonReceiverTest.cpp \

--- a/src/common.pri
+++ b/src/common.pri
@@ -9,5 +9,3 @@ OBJECTS_DIR = .obj
 MOC_DIR = .moc
 RCC_DIR = .rcc
 UI_DIR = .ui
-
-LIBS += -lSimpleAmqpClient -lrabbitmq


### PR DESCRIPTION
# [SFT-93](https://jira.calgarysolarcar.ca/browse/SFT-93)

Draft PR cause documentation, the EpsilonDashboardSetup.sh script, fix Travis and RPI testing.

At any rate, this PR adds Conan as an attempt to remove the shared gtest and SimpleAmqpClient requirements from the RPI, and package these into the binary during compilation time instead. We will still need to install the RabbitMQ server since it's not a C++ dependency.

Run by following the (temporary) instructions in setup.md, and then running build.sh in the root Epsilon-Dashboard directory. I'd recommend removing the build directory before running it, just to be on the safe side. Need to somehow add the `conan install` command to QT Creator's build process, gonna investigate that before merging this in.

### But why SFT-93? What does this have to do with compiling on Windows?
Installing all the dependencies sucks, but particularly on Windows. Making the dependencies all available from simple downloads (RabbitMQ is an exe, Conan can be installed through Python/pip which is another exe) should make it easier to run this on Windows (*if we can*, we should be able to but haven't tested this far yet)