### PR TITLE
Change the way default values are handle

### DIFF
--- a/src/InfrastructureLayer/Settings/I_Settings.h
+++ b/src/InfrastructureLayer/Settings/I_Settings.h
@@ -16,5 +16,4 @@ public:
     virtual bool customQueueEnable() const = 0;
 
     virtual void setQueueName(QString queueName) = 0;
-    virtual void setDefaultValue() = 0;
 };

--- a/src/InfrastructureLayer/Settings/I_Settings.h
+++ b/src/InfrastructureLayer/Settings/I_Settings.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <QSettings>
 
 class I_Settings
 {
@@ -15,4 +16,5 @@ public:
     virtual bool customQueueEnable() const = 0;
 
     virtual void setQueueName(QString queueName) = 0;
+    virtual void setDefaultValue() = 0;
 };

--- a/src/InfrastructureLayer/Settings/Settings.cpp
+++ b/src/InfrastructureLayer/Settings/Settings.cpp
@@ -26,7 +26,32 @@ Settings::Settings(QString filepath)
 {
     if (settings_.value(IP_ADDRESS).isNull())
     {
-        setDefaultValue();
+        settings_.setValue(IP_ADDRESS, DEFAULT_IP);
+    }
+
+    if (settings_.value(PORT).isNull())
+    {
+        settings_.setValue(PORT, DEFAULT_PORT);
+    }
+
+    if (settings_.value(PACKET_TITLE).isNull())
+    {
+        settings_.setValue(PACKET_TITLE, DEFAULT_PACKET_TITLE);
+    }
+
+    if (settings_.value(EXCHANGE_NAME).isNull())
+    {
+        settings_.setValue(EXCHANGE_NAME, DEFAULT_EXCHANGE_NAME);
+    }
+
+    if (settings_.value(CUSTOM_QUEUE_ENABLE).isNull())
+    {
+        settings_.setValue(CUSTOM_QUEUE_ENABLE, false);
+    }
+
+    if (settings_.value(LOGGING_ENABLED).isNull())
+    {
+        settings_.setValue(LOGGING_ENABLED, true);
     }
 }
 
@@ -67,14 +92,4 @@ bool Settings::customQueueEnable() const
 void Settings::setQueueName(QString queueName)
 {
     settings_.setValue(QUEUE_NAME, queueName);
-}
-
-void Settings::setDefaultValue()
-{
-    settings_.setValue(IP_ADDRESS, DEFAULT_IP);
-    settings_.setValue(PORT, DEFAULT_PORT);
-    settings_.setValue(PACKET_TITLE, DEFAULT_PACKET_TITLE);
-    settings_.setValue(EXCHANGE_NAME, DEFAULT_EXCHANGE_NAME);
-    settings_.setValue(CUSTOM_QUEUE_ENABLE, false);
-    settings_.setValue(LOGGING_ENABLED, true);
 }

--- a/src/InfrastructureLayer/Settings/Settings.cpp
+++ b/src/InfrastructureLayer/Settings/Settings.cpp
@@ -24,31 +24,34 @@ namespace
 Settings::Settings(QString filepath)
     : settings_(filepath, SETTINGS_FILE_FORMAT)
 {
+    if(settings_.value(IP_ADDRESS).isNull()){
+        setDefaultValue();
+    }
 }
 
 QString Settings::ipAddress() const
 {
-    return QString(settings_.value(IP_ADDRESS, DEFAULT_IP).toString());
+    return QString(settings_.value(IP_ADDRESS).toString());
 }
 
 quint16 Settings::port() const
 {
-    return (quint16)settings_.value(PORT, DEFAULT_PORT).toInt();
+    return (quint16)settings_.value(PORT).toInt();
 }
 
 QString Settings::packetTitle() const
 {
-    return settings_.value(PACKET_TITLE, DEFAULT_PACKET_TITLE).toString();
+    return settings_.value(PACKET_TITLE).toString();
 }
 
 QString Settings::exchange() const
 {
-    return QString(settings_.value(EXCHANGE_NAME, DEFAULT_EXCHANGE_NAME).toString());
+    return QString(settings_.value(EXCHANGE_NAME).toString());
 }
 
 QString Settings::queue() const
 {
-    return QString(settings_.value(QUEUE_NAME, DEFAULT_QUEUE_NAME).toString());
+    return QString(settings_.value(QUEUE_NAME).toString());
 }
 
 bool Settings::logging() const
@@ -63,4 +66,14 @@ bool Settings::customQueueEnable() const
 void Settings::setQueueName(QString queueName)
 {
     settings_.setValue(QUEUE_NAME, queueName);
+}
+
+void Settings::setDefaultValue()
+{
+    settings_.setValue(IP_ADDRESS, DEFAULT_IP);
+    settings_.setValue(PORT, DEFAULT_PORT);
+    settings_.setValue(PACKET_TITLE, DEFAULT_PACKET_TITLE);
+    settings_.setValue(EXCHANGE_NAME, DEFAULT_EXCHANGE_NAME);
+    settings_.setValue(CUSTOM_QUEUE_ENABLE, false);
+    settings_.setValue(LOGGING_ENABLED, true);
 }

--- a/src/InfrastructureLayer/Settings/Settings.cpp
+++ b/src/InfrastructureLayer/Settings/Settings.cpp
@@ -24,7 +24,8 @@ namespace
 Settings::Settings(QString filepath)
     : settings_(filepath, SETTINGS_FILE_FORMAT)
 {
-    if(settings_.value(IP_ADDRESS).isNull()){
+    if (settings_.value(IP_ADDRESS).isNull())
+    {
         setDefaultValue();
     }
 }

--- a/src/InfrastructureLayer/Settings/Settings.h
+++ b/src/InfrastructureLayer/Settings/Settings.h
@@ -15,7 +15,6 @@ public:
     bool logging() const;
     bool customQueueEnable() const;
     void setQueueName(QString queueName);
-    void setDefaultValue();
 
 private:
     QSettings settings_ ;

--- a/src/InfrastructureLayer/Settings/Settings.h
+++ b/src/InfrastructureLayer/Settings/Settings.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <QSettings>
-
 #include "I_Settings.h"
 
 class Settings : public I_Settings
@@ -17,6 +15,7 @@ public:
     bool logging() const;
     bool customQueueEnable() const;
     void setQueueName(QString queueName);
+    void setDefaultValue();
 
 private:
     QSettings settings_ ;


### PR DESCRIPTION
Now, when the dashboard doesn't detect a config.ini file, it will generate it own using defaults values found in the config.ini.example file.